### PR TITLE
tools: Use semver package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     pytest-xdist>=3.3.1,<4
     coincurve==17.0.0
     trie==2.1.1
+    semver==3.0.1
 
 [options.package_data]
 ethereum_test_tools =

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -3,12 +3,12 @@ Common pytest fixtures for ethereum_test_tools tests.
 """
 
 import pytest
-from packaging import version
+from semver import Version
 
 from ..code import Yul
 
 SUPPORTED_SOLC_VERSIONS = [
-    version.parse(v)
+    Version.parse(v)
     for v in [
         "0.8.20",
         "0.8.21",
@@ -17,9 +17,9 @@ SUPPORTED_SOLC_VERSIONS = [
 
 
 @pytest.fixture(scope="session")
-def solc_version() -> version.Version:
+def solc_version() -> Version:
     """Return the version of solc being used for tests."""
-    solc_version = version.parse(Yul("").version().split("+")[0])
+    solc_version = Yul("").version().finalize_version()
     if solc_version not in SUPPORTED_SOLC_VERSIONS:
         raise Exception("Unsupported solc version: {}".format(solc_version))
     return solc_version

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -6,7 +6,7 @@ from string import Template
 from typing import SupportsBytes
 
 import pytest
-from packaging import version
+from semver import Version
 
 from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get_deployed_forks
 
@@ -72,11 +72,11 @@ def yul_code(request: pytest.FixtureRequest, fork: Fork, padding_before: str, pa
     return compiled_yul_code
 
 
-SOLC_PADDING_VERSION = version.parse("0.8.21")
+SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
 
 @pytest.fixture()
-def expected_bytes(request: pytest.FixtureRequest, solc_version: version.Version, fork: Fork):
+def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: Fork):
     """Return the expected bytes for the test."""
     expected_bytes = request.param
     if isinstance(expected_bytes, Template):

--- a/src/ethereum_test_tools/tests/test_filler.py
+++ b/src/ethereum_test_tools/tests/test_filler.py
@@ -7,7 +7,7 @@ import os
 from typing import Any, Dict, List
 
 import pytest
-from packaging import version
+from semver import Version
 
 from ethereum_test_forks import Berlin, Fork, Istanbul, London
 from evm_transition_tool import GethTransitionTool
@@ -25,16 +25,16 @@ def remove_info(fixture_json: Dict[str, Any]):
 
 
 @pytest.fixture()
-def hash(request: pytest.FixtureRequest, solc_version: version.Version):
+def hash(request: pytest.FixtureRequest, solc_version: Version):
     """
     Set the hash based on the fork and solc version.
     """
-    if solc_version == version.parse("0.8.20"):
+    if solc_version == Version.parse("0.8.20"):
         if request.node.funcargs["fork"] == Berlin:
             return bytes.fromhex("193e550de3")
         elif request.node.funcargs["fork"] == London:
             return bytes.fromhex("b053deac0e")
-    elif solc_version == version.parse("0.8.21"):
+    elif solc_version == Version.parse("0.8.21"):
         if request.node.funcargs["fork"] == Berlin:
             return bytes.fromhex("f3a35d34f6")
         elif request.node.funcargs["fork"] == London:


### PR DESCRIPTION
Use semantic versioning package recommended by Sam.

I had to workaround because the current version I have installed breaks the package because it includes unexpected characters in the build metadata: 0.8.20+commit.a1b79de6.Linux.g **++**

Also the pre-release version mentioned in the discord (`0.8.20-develop.2023.5.1+commit.0cb27949.Darwin.appleclang`) is technically a lower version of our supported versions, `0.8.20` and `0.8.21`, so I'm a bit unsure if something else will break.

For this reason I added a hack to remove the pre-release from the parsed version so that `"0.8.20-develop.2023.5.1+commit.0cb27949.Darwin.appleclang" in ["0.8.20", "0.8.21"]`, by using `finalize_version()`.