### PR TITLE
Framework/test add fill versioning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: Post Release Jobs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # TODO: add changelog entry updates
+      - name: Update version in setup.cfg
+        run: |
+          NEW_VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/^v//')
+          sed -i "s/^version = .*/version = $NEW_VERSION/" setup.cfg
+          
+      - name: Commit and push changes
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add setup.cfg
+          git commit -m "Release EEST `${{ github.event.release.tag_name }}`"
+          git push origin HEAD:${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,19 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   update-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # TODO: add changelog entry updates
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: true
+          fetch-depth: 0
+
       - name: Update version in setup.cfg
         run: |
           NEW_VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/^v//')

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ lint =
     flake8>=6.1.0,<7
     pep8-naming==0.13.3
     fname8>=0.0.3
+    GitPython>=3.1
 
 docs =
     cairosvg>=2.7.0,<3  # required for social plugin (material)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
-name = test-filler
+name = execution-spec-tests
 description = Ethereum execution client test authoring framework
 long_description = file: README.md
 long_description_content_type = text/markdown
-version = 1.0.0
+version = v2.1.0
 url = https://github.com/ethereum/execution-spec-tests
 license_files =
     LICENSE

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -53,9 +53,9 @@ from .spec import (
     StateTest,
     StateTestFiller,
     TestInfo,
-    get_framework_version,
 )
 from .spec.blockchain.types import Block, Header
+from .utility.helpers import get_framework_version
 from .vm import Opcode, OpcodeCallArg, Opcodes
 
 __all__ = (

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -53,6 +53,7 @@ from .spec import (
     StateTest,
     StateTestFiller,
     TestInfo,
+    get_framework_version,
 )
 from .spec.blockchain.types import Block, Header
 from .vm import Opcode, OpcodeCallArg, Opcodes
@@ -112,5 +113,6 @@ __all__ = (
     "cost_memory_bytes",
     "eip_2028_transaction_data_cost",
     "eip_2028_transaction_data_cost",
+    "get_framework_version",
     "transaction_list_root",
 )

--- a/src/ethereum_test_tools/spec/__init__.py
+++ b/src/ethereum_test_tools/spec/__init__.py
@@ -1,9 +1,16 @@
 """
 Test spec definitions and utilities.
 """
+
 from typing import List, Type
 
-from .base.base_test import BaseFixture, BaseTest, TestSpec, verify_post_alloc
+from .base.base_test import (
+    BaseFixture,
+    BaseTest,
+    TestSpec,
+    get_framework_version,
+    verify_post_alloc,
+)
 from .blockchain.blockchain_test import BlockchainTest, BlockchainTestFiller, BlockchainTestSpec
 from .fixture_collector import FixtureCollector, TestInfo
 from .state.state_test import StateTest, StateTestFiller, StateTestOnly, StateTestSpec
@@ -24,5 +31,6 @@ __all__ = (
     "StateTestSpec",
     "TestInfo",
     "TestSpec",
+    "get_framework_version",
     "verify_post_alloc",
 )

--- a/src/ethereum_test_tools/spec/__init__.py
+++ b/src/ethereum_test_tools/spec/__init__.py
@@ -4,13 +4,7 @@ Test spec definitions and utilities.
 
 from typing import List, Type
 
-from .base.base_test import (
-    BaseFixture,
-    BaseTest,
-    TestSpec,
-    get_framework_version,
-    verify_post_alloc,
-)
+from .base.base_test import BaseFixture, BaseTest, TestSpec, verify_post_alloc
 from .blockchain.blockchain_test import BlockchainTest, BlockchainTestFiller, BlockchainTestSpec
 from .fixture_collector import FixtureCollector, TestInfo
 from .state.state_test import StateTest, StateTestFiller, StateTestOnly, StateTestSpec
@@ -31,6 +25,5 @@ __all__ = (
     "StateTestSpec",
     "TestInfo",
     "TestSpec",
-    "get_framework_version",
     "verify_post_alloc",
 )

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -4,13 +4,10 @@ Base test class and helper functions for Ethereum state and blockchain tests.
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from importlib.metadata import version
 from itertools import count
 from os import path
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Iterator, List, Mapping, Optional, TextIO
-
-from git import InvalidGitRepositoryError, Repo
 
 from ethereum_test_forks import Fork
 from evm_transition_tool import FixtureFormats, TransitionTool
@@ -20,6 +17,7 @@ from ...common.conversions import to_hex
 from ...common.json import JSONEncoder
 from ...common.json import field as json_field
 from ...reference_spec.reference_spec import ReferenceSpec
+from ...utility.helpers import get_framework_version
 
 
 def verify_transactions(txs: List[Transaction] | None, result) -> List[int]:
@@ -75,17 +73,6 @@ def verify_result(result: Mapping, env: Environment):
     """
     if env.withdrawals is not None:
         assert result["withdrawalsRoot"] == to_hex(withdrawals_root(env.withdrawals))
-
-
-def get_framework_version() -> str:
-    """
-    Returns the version of the EEST framework.
-    """
-    try:
-        local_commit_hash = Repo(search_parent_directories=True).head.commit.hexsha[:7]
-    except InvalidGitRepositoryError:  # required for some framework tests
-        local_commit_hash = "unknown"
-    return f"execution-spec-tests v{version('execution-spec-tests')}-{local_commit_hash}"
 
 
 @dataclass(kw_only=True)

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -2,15 +2,15 @@
 Base test class and helper functions for Ethereum state and blockchain tests.
 """
 
-import subprocess
 from abc import abstractmethod
 from dataclasses import dataclass, field
+from importlib.metadata import version
 from itertools import count
 from os import path
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Iterator, List, Mapping, Optional, TextIO
 
-import pkg_resources
+from git import InvalidGitRepositoryError, Repo
 
 from ethereum_test_forks import Fork
 from evm_transition_tool import FixtureFormats, TransitionTool
@@ -81,11 +81,11 @@ def get_framework_version() -> str:
     """
     Returns the version of the EEST framework.
     """
-    latest_release = pkg_resources.get_distribution("execution-spec-tests").version
-    local_commit_hash = (
-        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
-    )
-    return f"execution-spec-tests v{latest_release}-{local_commit_hash}"
+    try:
+        local_commit_hash = Repo(search_parent_directories=True).head.commit.hexsha[:7]
+    except InvalidGitRepositoryError:  # required for some framework tests
+        local_commit_hash = "unknown"
+    return f"execution-spec-tests v{version('execution-spec-tests')}-{local_commit_hash}"
 
 
 @dataclass(kw_only=True)

--- a/src/ethereum_test_tools/utility/__init__.py
+++ b/src/ethereum_test_tools/utility/__init__.py
@@ -1,0 +1,7 @@
+"""
+Utility functions used within the EEST framework.
+"""
+
+from .helpers import get_framework_version
+
+__all__ = ("get_framework_version",)

--- a/src/ethereum_test_tools/utility/helpers.py
+++ b/src/ethereum_test_tools/utility/helpers.py
@@ -1,0 +1,18 @@
+"""
+Utility functions for the EEST framework.
+"""
+
+from importlib.metadata import version
+
+from git import InvalidGitRepositoryError, Repo
+
+
+def get_framework_version() -> str:
+    """
+    Returns the current version of the EEST framework.
+    """
+    try:
+        local_commit_hash = Repo(search_parent_directories=True).head.commit.hexsha[:7]
+    except InvalidGitRepositoryError:  # required for some framework tests
+        local_commit_hash = "unknown"
+    return f"execution-spec-tests v{version('execution-spec-tests')}-{local_commit_hash}"

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -19,7 +19,14 @@ from ethereum_test_forks import (
     get_closest_fork_with_solc_support,
     get_forks_with_solc_support,
 )
-from ethereum_test_tools import SPEC_TYPES, BaseTest, FixtureCollector, TestInfo, Yul
+from ethereum_test_tools import (
+    SPEC_TYPES,
+    BaseTest,
+    FixtureCollector,
+    TestInfo,
+    Yul,
+    get_framework_version,
+)
 from evm_transition_tool import FixtureFormats, TransitionTool
 from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
 
@@ -126,6 +133,14 @@ def pytest_addoption(parser):
         help="Path to dump the transition tool debug output.",
     )
 
+    version_group = parser.getgroup("version_info", "Versioning of the EEST framework")
+    version_group.addoption(
+        "--version-info",
+        action="store_true",
+        default=False,
+        help="Displays the versioning information of the framework.",
+    )
+
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
@@ -174,6 +189,10 @@ def pytest_configure(config):
             f"Unsupported solc version: {config.solc_version}. Minimum required version is "
             f"{Frontier.solc_min_version()}",
             returncode=pytest.ExitCode.USAGE_ERROR,
+        )
+    if config.getoption("version_info"):
+        pytest.exit(
+            f"'Displaying framework version information'\n" f"> {get_framework_version()}\n"
         )
 
 

--- a/stubs/git/__init__.pyi
+++ b/stubs/git/__init__.pyi
@@ -1,0 +1,9 @@
+from typing import Any
+
+class Repo:
+    def __init__(self, path: str = ..., search_parent_directories: bool = ...) -> None: ...
+    @property
+    def head(self) -> Any: ...
+
+class InvalidGitRepositoryError(Exception):
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ development_fork = Cancun
 [testenv]
 package = wheel
 wheel_build_env = .pkg
-deps = GitPython
 
 [testenv:framework]
 description = Run checks on helper libraries and test framework

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ development_fork = Cancun
 [testenv]
 package = wheel
 wheel_build_env = .pkg
+deps = GitPython
 
 [testenv:framework]
 description = Run checks on helper libraries and test framework


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
