### PR TITLE
verkle: add eip-7709 test

### DIFF
--- a/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
+++ b/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
@@ -67,6 +67,7 @@ def test_blockhash_warm(blockchain_test: BlockchainTestFiller):
 
 
 @pytest.mark.valid_from("Verkle")
+@pytest.mark.skip(reason="TODO")
 def test_blockhash_insufficient_gas(blockchain_test: BlockchainTestFiller):
     """
     Test BLOCKHASH with insufficient gas.
@@ -117,8 +118,11 @@ def _blockhash(
 
     # TODO(verkle): fill right values when WitnessCheck allows to assert 2935 contract witness.
     hardcoded_blockhash = {
-        block_number - 2: Hash(0x1B027321A3F7FE2F073F9B9C654CF3E62ABD2A8324A198FD7C46D056BC3CE976),
-        block_number - BLOCKHASH_SERVE_WINDOW: Hash(0xCCCCCCCCC),
+        block_number - 2: Hash(0x127986F98B6BAB3B2AF5AC250912018D9982696E7B9B364D28190FA68C0AB49D),
+        block_number
+        - BLOCKHASH_SERVE_WINDOW: Hash(
+            0xBBB791529CE751AC1FDC021C21B0A7F13A22905BD5BB396EC3F57EBF97C0A14D
+        ),
     }
 
     # This is the condition described in EIP-7709 which doesn't return 0.

--- a/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
+++ b/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
@@ -55,7 +55,17 @@ def test_blockhash(blockchain_test: BlockchainTestFiller, blocknum_target: int):
     """
     Test BLOCKHASH witness.
     """
-    _blockhash(blockchain_test, blocknum_target)
+    # TODO(verkle): Today the only way to create these assertions is by hardcoding the values.
+    # If in the future the testing library can calculate these upfront, we should
+    # calculate them instead of hardcoding them.
+    hardcoded_blockhashes = {
+        block_number - 2: Hash(0x127986F98B6BAB3B2AF5AC250912018D9982696E7B9B364D28190FA68C0AB49D),
+        block_number
+        - BLOCKHASH_SERVE_WINDOW: Hash(
+            0xBBB791529CE751AC1FDC021C21B0A7F13A22905BD5BB396EC3F57EBF97C0A14D
+        ),
+    }
+    _blockhash(blockchain_test, blocknum_target, hardcoded_blockhashes)
 
 
 @pytest.mark.valid_from("Verkle")
@@ -63,7 +73,13 @@ def test_blockhash_warm(blockchain_test: BlockchainTestFiller):
     """
     Test BLOCKHASH witness with warm cost.
     """
-    _blockhash(blockchain_test, block_number - 2, warm=True)
+    # TODO(verkle): Today the only way to create these assertions is by hardcoding the values.
+    # If in the future the testing library can calculate these upfront, we should
+    # calculate them instead of hardcoding them.
+    hardcoded_blockhashes = {
+        block_number - 2: Hash(0x1B027321A3F7FE2F073F9B9C654CF3E62ABD2A8324A198FD7C46D056BC3CE976),
+    }
+    _blockhash(blockchain_test, block_number - 2, hardcoded_blockhashes, warm=True)
 
 
 @pytest.mark.valid_from("Verkle")
@@ -72,12 +88,13 @@ def test_blockhash_insufficient_gas(blockchain_test: BlockchainTestFiller):
     Test BLOCKHASH with insufficient gas for witness addition.
     """
     # 21_223 = 21_000 + (one code-chunk) 200 + (PUSH2) 3 + (BLOCKHASH constant cost) 20
-    _blockhash(blockchain_test, block_number - 2, gas_limit=21_223, fail=True)
+    _blockhash(blockchain_test, block_number - 2, {}, gas_limit=21_223, fail=True)
 
 
 def _blockhash(
     blockchain_test: BlockchainTestFiller,
     blocknum_target: int,
+    hardcoded_blockhashes: dict[int, Hash],
     gas_limit: int = 1_000_000,
     warm: bool = False,
     fail: bool = False,
@@ -116,19 +133,8 @@ def _blockhash(
     for i, chunk in enumerate(code_chunks, start=0):
         witness_check.add_code_chunk(address=TestAddress2, chunk_number=i, value=chunk)
 
-    # TODO(verkle): when system contract exhaustive checks are supported in the testing library,
-    # add here the 2935 actions on the witness too.
-
-    # TODO(verkle): Today the only way to create these assertions is by hardcoding the values.
-    # If in the future the testing library can calculate these upfront, we should
-    # calculate them instead of hardcoding them.
-    hardcoded_blockhash = {
-        block_number - 2: Hash(0x127986F98B6BAB3B2AF5AC250912018D9982696E7B9B364D28190FA68C0AB49D),
-        block_number
-        - BLOCKHASH_SERVE_WINDOW: Hash(
-            0xBBB791529CE751AC1FDC021C21B0A7F13A22905BD5BB396EC3F57EBF97C0A14D
-        ),
-    }
+    # TODO(verkle): when system contract exhaustive checks are supported in
+    #  the testing library, add here the 2935 actions on the witness too.
 
     # If the execution isn't expected to fail due to insufficient gas, and we satisfy the
     # block number target condition defined in the spec, we should assert the appropriate slot
@@ -139,7 +145,7 @@ def _blockhash(
         witness_check.add_storage_slot(
             system_contract_address,
             blocknum_target % HISTORY_SERVE_WINDOW,
-            hardcoded_blockhash.get(blocknum_target),
+            hardcoded_blockhashes.get(blocknum_target),
         )
 
     # The last block contains a single transaction with the BLOCKHASH instruction(s).

--- a/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
+++ b/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
@@ -67,12 +67,12 @@ def test_blockhash_warm(blockchain_test: BlockchainTestFiller):
 
 
 @pytest.mark.valid_from("Verkle")
-@pytest.mark.skip(reason="TODO")
 def test_blockhash_insufficient_gas(blockchain_test: BlockchainTestFiller):
     """
-    Test BLOCKHASH with insufficient gas.
+    Test BLOCKHASH with insufficient gas for witness addition.
     """
-    _blockhash(blockchain_test, block_number - 2, gas_limit=21_020, fail=True)
+    # 21_223 = 21_000 + (one code-chunk) 200 + (PUSH2) 3 + (BLOCKHASH constant cost) 20
+    _blockhash(blockchain_test, block_number - 2, gas_limit=21_223, fail=True)
 
 
 def _blockhash(
@@ -130,7 +130,9 @@ def _blockhash(
         ),
     }
 
-    # This is the condition described in EIP-7709 which doesn't return 0.
+    # If the execution isn't expected to fail due to insufficient gas, and we satisfy the
+    # block number target condition defined in the spec, we should assert the appropriate slot
+    # is in the witness.
     if not fail and not (
         blocknum_target >= block_number or blocknum_target + BLOCKHASH_SERVE_WINDOW < block_number
     ):

--- a/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
+++ b/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
@@ -26,9 +26,9 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7709.md"
 REFERENCE_SPEC_VERSION = "TODO"
 
 system_contract_address = Address("0xfffffffffffffffffffffffffffffffffffffffe")
-HISTORY_STORAGE_ADDRESS = 8192
+HISTORY_SERVE_WINDOW = 8192
 BLOCKHASH_SERVE_WINDOW = 256
-block_number = BLOCKHASH_SERVE_WINDOW + 10
+block_number = BLOCKHASH_SERVE_WINDOW + 5
 
 
 @pytest.mark.valid_from("Verkle")
@@ -51,7 +51,7 @@ block_number = BLOCKHASH_SERVE_WINDOW + 10
         "too_old_block",
     ],
 )
-def test_blockhash_foo(blockchain_test: BlockchainTestFiller, blocknum_target: int):
+def test_blockhash(blockchain_test: BlockchainTestFiller, blocknum_target: int):
     """
     Test BLOCKHASH witness.
     """
@@ -63,16 +63,15 @@ def test_blockhash_warm(blockchain_test: BlockchainTestFiller):
     """
     Test BLOCKHASH witness with warm cost.
     """
-    _blockhash(blockchain_test, block_number - 1, warm=True)
+    _blockhash(blockchain_test, block_number - 2, warm=True)
 
 
 @pytest.mark.valid_from("Verkle")
-@pytest.mark.skip(reason="Not fully implemented")
 def test_blockhash_insufficient_gas(blockchain_test: BlockchainTestFiller):
     """
     Test BLOCKHASH with insufficient gas.
     """
-    _blockhash(blockchain_test, block_number - 1, gas_limit=21_042, fail=True)
+    _blockhash(blockchain_test, block_number - 2, gas_limit=21_020, fail=True)
 
 
 def _blockhash(
@@ -118,17 +117,17 @@ def _blockhash(
 
     # TODO(verkle): fill right values when WitnessCheck allows to assert 2935 contract witness.
     hardcoded_blockhash = {
-        block_number - 2: Hash(0xCC0C2DF843A33778952AA863B345DF9AE80D68ABF83C8C4B973B0B4A20D0FAC2),
+        block_number - 2: Hash(0x1B027321A3F7FE2F073F9B9C654CF3E62ABD2A8324A198FD7C46D056BC3CE976),
         block_number - BLOCKHASH_SERVE_WINDOW: Hash(0xCCCCCCCCC),
     }
 
     # This is the condition described in EIP-7709 which doesn't return 0.
-    if not (
+    if not fail and not (
         blocknum_target >= block_number or blocknum_target + BLOCKHASH_SERVE_WINDOW < block_number
     ):
         witness_check.add_storage_slot(
             system_contract_address,
-            blocknum_target % BLOCKHASH_SERVE_WINDOW,
+            blocknum_target % HISTORY_SERVE_WINDOW,
             hardcoded_blockhash.get(blocknum_target),
         )
 

--- a/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
+++ b/tests/verkle/eip7709_blockhash_witness/test_blockhash_instruction.py
@@ -116,7 +116,12 @@ def _blockhash(
     for i, chunk in enumerate(code_chunks, start=0):
         witness_check.add_code_chunk(address=TestAddress2, chunk_number=i, value=chunk)
 
-    # TODO(verkle): fill right values when WitnessCheck allows to assert 2935 contract witness.
+    # TODO(verkle): when system contract exhaustive checks are supported in the testing library,
+    # add here the 2935 actions on the witness too.
+
+    # TODO(verkle): Today the only way to create these assertions is by hardcoding the values.
+    # If in the future the testing library can calculate these upfront, we should
+    # calculate them instead of hardcoding them.
     hardcoded_blockhash = {
         block_number - 2: Hash(0x127986F98B6BAB3B2AF5AC250912018D9982696E7B9B364D28190FA68C0AB49D),
         block_number


### PR DESCRIPTION
This PR re-enables EIP-7709 by fixing all the existing problems.

There're some `TODO(verkle)` that we'll have to address after we figure out how to deal with some situations in the testing library. For now, we can live with the workarounds for a while without problems.
