### PR TITLE
chore(ci): use manual x-dist value for self-hosted runner

### DIFF
--- a/.github/configs/evm-impl.yaml
+++ b/.github/configs/evm-impl.yaml
@@ -1,15 +1,14 @@
 eels:
   evm-bin: ethereum-spec-evm-resolver
-  x-dist: auto
+  x-dist: 10
 geth:
   evm-bin: evm
-  x-dist: auto
 evmone:
   evm-bin: evmone-t8n
-  x-dist: auto
+  x-dist: 10
 besu:
   evm-bin: evmtool
   x-dist: 0
 ethjs:
   evm-bin: ethereumjs-t8ntool.sh
-  x-dist: auto
+  x-dist: 10

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -12,7 +12,3 @@ eip7692:
   fill-params: --fork=Osaka ./tests/osaka
   solc: 0.8.21
   eofwrap: true
-pectra-devnet-6:
-  evm-type: pectra-devnet-6
-  fill-params: --until=Prague
-  solc: 0.8.21


### PR DESCRIPTION
## 🗒️ Description
To speed up the release process I've added a new user to the hive server called `usainbolt`. This user will be used entirely as a self-hosted runner set for the`[Build and Package Fixtures](https://github.com/spencer-tb/execution-spec-tests/actions/workflows/fixtures.yaml) workflow step. Note this is only runs when creating new releases.

Currently our releases take a long time finish as fixture builds run sequentially, due to our single self-hosted runner instance. Everything in total currently takes around 5hrs. I've now added 6 self hosted runners.
<img width="618" alt="Screenshot 2025-03-11 at 11 49 51" src="https://github.com/user-attachments/assets/95452d38-c1db-417d-9688-702379aa26e7" />

This will take our entire release process time down to <3hrs. Note we could improve this by finding a way to fill the `slow` marked fixtures faster.

### Other Changes

- Removed `pectra-devnet-6` as a separate build, Prague tests are within develop now.
- Set `x-dist` to 10 instead of auto. With the self-hosted runners when using auto it will select `n=32` for each build. This will ultimately throttle the EELS resolver and give us timeout errors when filing.

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/pull/1051

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
